### PR TITLE
Verify SPAppToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ By plugging into Passport, SharePoint authentication can be easily and unobtrusi
 
     $ npm install passport-sharepoint
 
+## Breaking change
+
+Version 0.4.0 and higher will validate the `SPAppToken` as [recommended by Microsoft](https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/context-token-oauth-flow-for-sharepoint-add-ins#context-token-flow-steps). Tokens using a `none` algorithm, not signed with the `appSecret`, or expired, will be rejected.
+
 ## Usage
 
 #### Configure Strategy

--- a/lib/passport-sharepoint/strategy.js
+++ b/lib/passport-sharepoint/strategy.js
@@ -116,7 +116,7 @@ Strategy.prototype.authenticate = function(req, options) {
   // check if there is a app token present
   if (spAppToken && spSiteUrl) {
     try {
-      var token = jwt.decode(spAppToken, '', true);
+      var token = jwt.decode(spAppToken, this._appSecret);
       var splitApptxSender = token.appctxsender.split("@");
       var sharepointServer = url.parse(spSiteUrl)
       var resource = splitApptxSender[0]+"/"+sharepointServer.host+"@"+splitApptxSender[1];


### PR DESCRIPTION
### Description

Verify `SPAppToken` with the app secret.

Token needs to be verified as explained on step 6 of https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/context-token-oauth-flow-for-sharepoint-add-ins#context-token-flow-steps.

Example tokens in doc use HS256: https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/handle-security-tokens-in-provider-hosted-low-trust-sharepoint-add-ins#example-of-a-context-token . There are some reports on cases using RS256 though: https://collab365.community/forum/topics/sharepoint-app-why-would-i-be-getting-a-jwt-token-signed-with/ . This PR will only work for HS256 tokens.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] The correct base branch is being used, if not `master`
